### PR TITLE
fix(stripe bar): set colors to stripe bar for errors, warns,...

### DIFF
--- a/Tokyo Night.icls
+++ b/Tokyo Night.icls
@@ -426,6 +426,7 @@
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="db4b4b" />
+        <option name="ERROR_STRIPE_COLOR" value="db4b4b" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
@@ -456,6 +457,7 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="EFFECT_COLOR" value="c97018" />
+        <option name="ERROR_STRIPE_COLOR" value="c97018" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
@@ -502,6 +504,7 @@
     <option name="INFO_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="db9d7" />
+        <option name="ERROR_STRIPE_COLOR" value="db9d7" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
@@ -884,6 +887,13 @@
         <option name="FOREGROUND" value="9d7cd8" />
       </value>
     </option>
+    <option name="PY.SELF_PARAMETER">
+      <value>
+        <option name="FOREGROUND" value="d599e2" />
+        <option name="FONT_TYPE" value="2" />
+        <option name="EFFECT_TYPE" value="3" />
+      </value>
+    </option>
     <option name="REGEXP_MATCHED_GROUPS">
       <value>
         <option name="FOREGROUND" value="9aa5ce" />
@@ -940,6 +950,7 @@
       <value>
         <option name="BACKGROUND" value="283357" />
         <option name="EFFECT_COLOR" value="e0af68" />
+        <option name="ERROR_STRIPE_COLOR" value="283357" />
       </value>
     </option>
     <option name="TODO_DEFAULT_ATTRIBUTES">
@@ -975,6 +986,7 @@
     <option name="TYPO">
       <value>
         <option name="EFFECT_COLOR" value="646e9c" />
+        <option name="ERROR_STRIPE_COLOR" value="646e9c" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
@@ -986,6 +998,7 @@
     <option name="WARNING_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="e0af68" />
+        <option name="ERROR_STRIPE_COLOR" value="e0af68" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
@@ -1000,6 +1013,7 @@
     <option name="WRONG_REFERENCES_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="db4b4b" />
+        <option name="ERROR_STRIPE_COLOR" value="db4b4b" />
         <option name="EFFECT_TYPE" value="1" />
       </value>
     </option>


### PR DESCRIPTION
## Before
![image](https://user-images.githubusercontent.com/25200594/105492345-1c17ed00-5cb8-11eb-9320-0f5a59cfe76b.png)

## After
![image](https://user-images.githubusercontent.com/25200594/105492365-22a66480-5cb8-11eb-8b99-1179237c7319.png)

## Tested IDEs
- PyCharm 2020.3.2 (Professional Edition)
Build #PY-203.6682.179, built on December 30, 2020